### PR TITLE
HC-45 Sciflo sets log format with custom attribute on root log handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 build
 *.egg-info
+.eggs
+.idea

--- a/sciflo/grid/funcs.py
+++ b/sciflo/grid/funcs.py
@@ -32,8 +32,13 @@ else:
     logging._acquireLock()
     try:
         LOG_FMT = "%(asctime)s %(name)s %(id)s %(levelname)s: %(message)s"
-        logging.basicConfig(format=LOG_FMT)
+        datefmt = '%Y-%m-%d %H:%M:%S'
+        worker_formatter = logging.Formatter(fmt=LOG_FMT, datefmt=datefmt)
+        worker_handler = logging.StreamHandler(stream=sys.stderr)
+        worker_handler.setFormatter(worker_formatter)
+
         WORKER_LOGGER = logging.getLogger('workUnitWorker')
+        WORKER_LOGGER.addHandler(worker_handler)
     finally:
         logging._releaseLock()
 WORKER_LOGGER.setLevel(logging.DEBUG)

--- a/scripts/sflExec.py
+++ b/scripts/sflExec.py
@@ -244,7 +244,7 @@ def configure_logging():
     level = logging.INFO
     datefmt = '%Y-%m-%d %H:%M:%S'
     if len(logging.getLogger().handlers) == 0:
-        logging.basicConfig(format=logformat, level=level, datefmt=datefmt, stream=sys.stdout)
+        logging.basicConfig(format=logformat, level=level, datefmt=datefmt, stream=sys.stderr)
     else:
         formatter = logging.Formatter(fmt=logformat, datefmt=datefmt)
         for handler in logging.getLogger().handlers:

--- a/scripts/sflExec.py
+++ b/scripts/sflExec.py
@@ -12,6 +12,7 @@
 import os
 import sys
 import getopt
+import logging
 import types
 import pwd
 import lxml.etree
@@ -192,6 +193,10 @@ def main():
             key, val = argsItem.split('=')
             argsDict[key] = val
 
+    # If verbose or debug flag was specified, enable debug logs on root logger and handlers
+    if verbose or debug:
+        enable_debug_logging()
+
     # get results and ScifloManager
     # (results, m) = sciflo.grid.sflExec(getuser(), xml, argsDict, outDir=outputDir,
     #                                   scifloid=None, config=configFile,
@@ -226,6 +231,25 @@ def restoreScreen():
     curses.nocbreak()
     curses.echo()
     curses.endwin()
+
+
+def enable_debug_logging():
+    logging.getLogger().setLevel(logging.DEBUG)
+    for handler in logging.getLogger().handlers:
+        handler.setLevel(logging.DEBUG)
+
+
+def configure_logging():
+    logformat = '%(asctime)s %(name)s:%(levelname)s [%(filename)s:%(lineno)d] %(message)s'
+    level = logging.INFO
+    datefmt = '%Y-%m-%d %H:%M:%S'
+    if len(logging.getLogger().handlers) == 0:
+        logging.basicConfig(format=logformat, level=level, datefmt=datefmt, stream=sys.stdout)
+    else:
+        formatter = logging.Formatter(fmt=logformat, datefmt=datefmt)
+        for handler in logging.getLogger().handlers:
+            handler.setLevel(level)
+            handler.setFormatter(formatter)
 
 
 if __name__ == '__main__':

--- a/scripts/sflExec.py
+++ b/scripts/sflExec.py
@@ -253,6 +253,7 @@ def configure_logging():
 
 
 if __name__ == '__main__':
+    configure_logging()
     tracebackStrIO = StringIO()
     results = Exception("Preset exception.")
     resStrList = None


### PR DESCRIPTION
This PR changes the `workUnitWorker` logger so that it defines a custom handler and format for that specific handler.

Previously, `logging.basicConfig()` was being used to set the log format. This sets the log format on the root logger. Because the log format includes a custom attribute (`id`), this causes errors in other modules that use the root logger to log messages without the custom `id` attribute.

By registering a custom handler with a custom format only with the `workUnitWorker` logger, this conflict will no longer happen.