### PR TITLE
HC-421: Return non-0 exit code when disk space fills up

### DIFF
--- a/sciflo/grid/executor.py
+++ b/sciflo/grid/executor.py
@@ -652,7 +652,7 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
             self.logger.debug("Got error in shutdown() for sciflo '%s':%s\n%s" %
                               (self.scifloName, str(e), getTb()),
                               extra={'id': self.scifloid})
-            os._exit(0)
+            os._exit(1)
 
     def callback(self, callbackResult):
         """Callback for work unit execution."""

--- a/sciflo/grid/executor.py
+++ b/sciflo/grid/executor.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import time
 import gc
@@ -653,7 +654,7 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
             self.logger.debug("Got OSError in shutdown() for sciflo '%s':%s\n%s" %
                               (self.scifloName, str(oe), getTb()),
                               extra={'id': self.scifloid})
-            if oe.errno == 28:
+            if oe.errno == errno.ENOSPC:
                 os._exit(1)
             else:
                 os._exit(0)

--- a/sciflo/grid/executor.py
+++ b/sciflo/grid/executor.py
@@ -647,12 +647,22 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
                                            'workunit_result-%d.txt' % i)
                     with open(resFile, 'w') as f:
                         f.write("%s\n" % self.output[i])
+        except OSError as oe:
+            # When disk space fills up during the middle of a Sciflo run, catch it
+            # here and return a non-0 exit code.
+            self.logger.debug("Got OSError in shutdown() for sciflo '%s':%s\n%s" %
+                              (self.scifloName, str(oe), getTb()),
+                              extra={'id': self.scifloid})
+            if oe.errno == 28:
+                os._exit(1)
+            else:
+                os._exit(0)
 
         except Exception as e:
             self.logger.debug("Got error in shutdown() for sciflo '%s':%s\n%s" %
                               (self.scifloName, str(e), getTb()),
                               extra={'id': self.scifloid})
-            os._exit(1)
+            os._exit(0)
 
     def callback(self, callbackResult):
         """Callback for work unit execution."""

--- a/sciflo/grid/executor.py
+++ b/sciflo/grid/executor.py
@@ -650,7 +650,9 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
                         f.write("%s\n" % self.output[i])
         except OSError as oe:
             # When disk space fills up during the middle of a Sciflo run, catch it
-            # here and return a non-0 exit code.
+            # here and return a non-0 exit code. To achieve backwards compatability,
+            # we only want to return a non-0 for disk full cases. We'll update
+            # the logic if needed in the future.
             self.logger.debug("Got OSError in shutdown() for sciflo '%s':%s\n%s" %
                               (self.scifloName, str(oe), getTb()),
                               extra={'id': self.scifloid})

--- a/sciflo/grid/funcs.py
+++ b/sciflo/grid/funcs.py
@@ -100,22 +100,17 @@ def forkChildAndRun(q, func, *args, **kargs):
             else:
                 tres = res[0]
             res = (tres, res[1])
-            try:
-                with open(pickleFile, 'wb') as p:
-                    try:
-                        pickle.dump(res, p)
-                    except:
-                        pickle.dump((RuntimeError(str(res[0])), res[1]), p)
-            except OSError as oe:
-                raise
+            with open(pickleFile, 'wb') as p:
+                try:
+                    pickle.dump(res, p)
+                except:
+                    pickle.dump((RuntimeError(str(res[0])), res[1]), p)
         except Exception as e:
             WORKER_LOGGER.debug("Error in forkChildAndRun: %s" % getTb(),
                                 extra={'id': 'child'})
-            try:
-                with open(pickleFile, 'wb') as p:
-                    pickle.dump(e, p)
-            except OSError as oe:
-                raise
+            with open(pickleFile, 'wb') as p:
+                pickle.dump(e, p)
+
         os._exit(0)
 
     # install handler for SIGTERM

--- a/sciflo/grid/funcs.py
+++ b/sciflo/grid/funcs.py
@@ -100,16 +100,22 @@ def forkChildAndRun(q, func, *args, **kargs):
             else:
                 tres = res[0]
             res = (tres, res[1])
-            with open(pickleFile, 'wb') as p:
-                try:
-                    pickle.dump(res, p)
-                except:
-                    pickle.dump((RuntimeError(str(res[0])), res[1]), p)
+            try:
+                with open(pickleFile, 'wb') as p:
+                    try:
+                        pickle.dump(res, p)
+                    except:
+                        pickle.dump((RuntimeError(str(res[0])), res[1]), p)
+            except OSError as oe:
+                raise
         except Exception as e:
             WORKER_LOGGER.debug("Error in forkChildAndRun: %s" % getTb(),
                                 extra={'id': 'child'})
-            with open(pickleFile, 'wb') as p:
-                pickle.dump(e, p)
+            try:
+                with open(pickleFile, 'wb') as p:
+                    pickle.dump(e, p)
+            except OSError as oe:
+                raise
         os._exit(0)
 
     # install handler for SIGTERM

--- a/sciflo/grid/funcs.py
+++ b/sciflo/grid/funcs.py
@@ -110,7 +110,6 @@ def forkChildAndRun(q, func, *args, **kargs):
                                 extra={'id': 'child'})
             with open(pickleFile, 'wb') as p:
                 pickle.dump(e, p)
-
         os._exit(0)
 
     # install handler for SIGTERM

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ scripts = [os.path.join('scripts', 'sflExec.py'),
 data_files = [('tac', [os.path.join('tac', 'PersistentDictServer.tac')])]
 
 setup(name='sciflo',
-      version = "1.3.5",
+      version = "1.3.6",
       description="SciFlo workflow framework and engine",
       url="https://github.com/hysds/sciflo",
       author='Brian Wilson',


### PR DESCRIPTION
This PR updates Sciflo such that if there is no more disk space while it is running, it will return a non-0 exit code. Previously, it was always returning 0, which caused verdi to flag the job as "job completed".

To err on the side of caution, as well as to achieve backwards compatibility, we are only going to throw a non-0 exit code specifically for disk space full use cases.

```
2022-05-24 21:25:56 PGE_L1B_LR_INTF:DEBUG [executor.py:654] Got OSError in shutdown() for sciflo 'PGE_L1B_LR_INTF':[Errno 28] No space left on device: '/data/work/jobs/2022/05/24/21/22/SCIFLO_L1B_LR_INTF__SSDS-2234-L1B_LR_INTF_001_175-state-config-20220524T174647.588944Z/output/workunit_result-0.txt'
Exception Type: <class 'OSError'>
Exception Value: [Errno 28] No space left on device: '/data/work/jobs/2022/05/24/21/22/SCIFLO_L1B_LR_INTF__SSDS-2234-L1B_LR_INTF_001_175-state-config-20220524T174647.588944Z/output/workunit_result-0.txt'
Traceback (most recent call last):
  File "/home/ops/verdi/ops/sciflo/sciflo/grid/executor.py", line 643, in shutdown
    with open(resFile, 'w') as f:
OSError: [Errno 28] No space left on device: '/data/work/jobs/2022/05/24/21/22/SCIFLO_L1B_LR_INTF__SSDS-2234-L1B_LR_INTF_001_175-state-config-20220524T174647.588944Z/output/workunit_result-0.txt'

Running sflExec.py command:
/home/ops/verdi/bin/sflExec.py -s -f -o output --args "sf_context=/data/work/jobs/2022/05/24/21/22/SCIFLO_L1B_LR_INTF__SSDS-2234-L1B_LR_INTF_001_175-state-config-20220524T174647.588944Z/_context.json" /home/ops/verdi/ops/swot-pcm/swot_chimera/wf_xml/L1B_LR_INTF.sf.xml
Exit status is: 256
```

Regarding the circleci test failures, spoke with @pymonger on this and the suggestion was to run it on Mozart due to a known issue with running the sciflo test through Circleci. I ran the unit tests on Mozart and it passed:
![image](https://user-images.githubusercontent.com/42812746/170156426-a2886743-f2d3-41a8-b553-9c2c1206065d.png)
