### PR TITLE
HC-522: Create sciflo working directory in a temp dir if creating it at $HOME fails

### DIFF
--- a/sciflo/utils/misc.py
+++ b/sciflo/utils/misc.py
@@ -851,11 +851,11 @@ SCIFLO_CONFIG_XML_TEMPLATE = Template('''<?xml version="1.0"?>
 ''')
 
 
-def getUserScifloConfig(userConfigFile=None, globalConfigFile=None, workDir=None):
+def getUserScifloConfig(userConfigFile=None, globalConfigFile=None):
     """Return path to user's sciflo config."""
 
     # get user info
-    userName, homeDir, userScifloDir, userConfig = getUserInfo(workDir)
+    userName, homeDir, userScifloDir, userConfig = getUserInfo()
     if userConfigFile is None:
         userConfigFile = userConfig
     userScifloConfigFile = os.path.join(userScifloDir, '.scifloConfig.xml')

--- a/sciflo/utils/misc.py
+++ b/sciflo/utils/misc.py
@@ -685,7 +685,7 @@ IMPLICIT_CONVERSIONS = ('sf:localUrlsListNoDods', 'sf:localUrlsList',
                         'sf:localFilesNoDods')
 
 
-def getUserInfo(workDir=None):
+def getUserInfo():
     """Return tuple of (username, home directory, user's sciflo config directory, and
     sciflo config file).  If user sciflo directory does not exist, create it.  If
     config file doesn't exist, generate default file.

--- a/sciflo/utils/misc.py
+++ b/sciflo/utils/misc.py
@@ -8,6 +8,7 @@
 # Copyright:   (c) 2005, California Institute of Technology.
 #              U.S. Government Sponsorship acknowledged.
 # -----------------------------------------------------------------------------
+import tempfile
 import types
 import os
 import urllib.parse
@@ -692,7 +693,8 @@ def getUserInfo():
 
     userInfo = pwd.getpwuid(os.getuid())
     userName = userInfo[0]
-    homeDir = userInfo[5]
+    # homeDir = userInfo[5]
+    homeDir = tempfile.gettempdir()
     userScifloDir = os.path.join(homeDir, '.sciflo')
     if not os.path.isdir(userScifloDir):
         os.makedirs(userScifloDir, 0o755)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ scripts = [os.path.join('scripts', 'sflExec.py'),
 data_files = [('tac', [os.path.join('tac', 'PersistentDictServer.tac')])]
 
 setup(name='sciflo',
-      version = "1.3.6",
+      version = "1.3.7",
       description="SciFlo workflow framework and engine",
       url="https://github.com/hysds/sciflo",
       author='Brian Wilson',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(name='sciflo',
       install_requires=[
           'twisted>=18.9.0', 'pillow>=5.4.1', 'formencode>=1.3.1',
           'sqlobject>=3.7.1', 'service_identity>=18.1.0',
-          'python-magic>=0.4.15'
+          'python-magic>=0.4.15',
+          # pin setuptools until this is fixed: https://github.com/pypa/setuptools/issues/4399
+          "setuptools<70.0.0"
       ],
       packages=packages,
       package_data={

--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ setup(name='sciflo',
       install_requires=[
           'twisted>=18.9.0', 'pillow>=5.4.1', 'formencode>=1.3.1',
           'sqlobject>=3.7.1', 'service_identity>=18.1.0',
-          'python-magic>=0.4.15',
-          # pin setuptools until this is fixed: https://github.com/pypa/setuptools/issues/4399
-          "setuptools<70.0.0"
+          'python-magic>=0.4.15'
       ],
       packages=packages,
       package_data={


### PR DESCRIPTION
This PR updates how Sciflo creates it's internal sciflo-related working files and directories. Nominally, it would write to $HOME. However, when testing with podman and keeping with the user namespace paradigm, it was discovered that we would run into `permission denied` errors when running Sciflo jobs since it was trying to create a `/home/ops/.sciflo` directory within the container, which is owned by `ops`. However, in this case, we were running podman as `hysdsops`, so we were not allowed to write to that area.

Therefore, in order to maintain backwards compatibility, the solution is to still try and create the sciflo directory under $HOME and surround this with a try/except block to catch a permission error. Under that use case, we will fallback to creating the directory under a temporary directory location instead (i.e. /tmp)