### PR TITLE
HC-563: python 3.12 compatibility updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:HC-563
+      - image: hysds/pge-base:latest
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: hysds/pge-base:latest
+      - image: hysds/pge-base:HC-563
         auth:
           username: $DOCKER_USER
           password: $DOCKER_PASS

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,8 @@ jobs:
           no_output_timeout: 30m
           command: |
             source $HOME/verdi/bin/activate
-            pip install j2cli
-            j2 --undefined $HOME/verdi/ops/hysds/configs/celery/celeryconfig.py.tmpl -o $HOME/verdi/ops/hysds/celeryconfig.py
+            pip install jinjanator
+            jinjanate --undefined $HOME/verdi/ops/hysds/configs/celery/celeryconfig.py.tmpl -o $HOME/verdi/ops/hysds/celeryconfig.py
             pytest -s $(find test -name "*Test.py")
           environment:
             MOZART_ES_PVT_IP: 127.0.0.1

--- a/sciflo/db/bsddbStore.py
+++ b/sciflo/db/bsddbStore.py
@@ -32,7 +32,7 @@ class BsddbStore(Store):
         """Constructor."""
 
         # call super()
-        super(BsddbStore, self).__init__(name, fieldsList)
+        super().__init__(name, fieldsList)
 
         # set db attributes
         self._dbHome = dbHome

--- a/sciflo/db/dbtablesCDB.py
+++ b/sciflo/db/dbtablesCDB.py
@@ -259,7 +259,7 @@ class bsdTableDB:
         try:
             key, data = cur.first()
             while 1:
-                print((repr({key: data})))
+                print(repr({key: data}))
                 next = next(cur)
                 if next:
                     key, data = next
@@ -404,9 +404,9 @@ class bsdTableDB:
         try:
             tcolpickles = self.db.get(_columns_key(table))
         except DBNotFoundError:
-            raise TableDBError("unknown table: %r" % (table,))
+            raise TableDBError("unknown table: {!r}".format(table))
         if not tcolpickles:
-            raise TableDBError("unknown table: %r" % (table,))
+            raise TableDBError("unknown table: {!r}".format(table))
         self.__tablecolumns[table] = pickle.loads(tcolpickles)
 
     # def __new_rowid(self, table, txn) :
@@ -450,7 +450,7 @@ class bsdTableDB:
                 self.__load_column_info(table)
             for column in list(rowdict.keys()):
                 if not self.__tablecolumns[table].count(column):
-                    raise TableDBError("unknown column: %r" % (column,))
+                    raise TableDBError("unknown column: {!r}".format(column))
 
             # get a unique row identifier for this row
             #txn = self.env.txn_begin()
@@ -617,7 +617,7 @@ class bsdTableDB:
             columns = self.tablecolumns[table]
         for column in (columns + list(conditions.keys())):
             if not self.__tablecolumns[table].count(column):
-                raise TableDBError("unknown column: %r" % (column,))
+                raise TableDBError("unknown column: {!r}".format(column))
 
         # keyed on rows that match so far, containings dicts keyed on
         # column names containing the data for that row and column.

--- a/sciflo/db/rdbmsStore.py
+++ b/sciflo/db/rdbmsStore.py
@@ -65,7 +65,7 @@ class RdbmsStore(Store):
         """Constructor."""
 
         # call super()
-        super(RdbmsStore, self).__init__(name, fieldsList)
+        super().__init__(name, fieldsList)
 
         # set db attributes
         self._dbHome = dbHome

--- a/sciflo/db/scifloDb.py
+++ b/sciflo/db/scifloDb.py
@@ -116,7 +116,7 @@ def getCreateSql(tableName, xml, recordTag, autoKey=False):
     retStr = "create table %s (\n" % tableName
     if autoKey:
         retStr += "    id int primary key auto_increment,\n"
-    fieldStrList = ["    %s %s" % (field, sqltype)
+    fieldStrList = ["    {} {}".format(field, sqltype)
                     for field, sqltype in sqlCreateInfoList]
     return retStr + ",\n".join(fieldStrList) + ")"
 
@@ -175,7 +175,7 @@ class ScifloDbTableError(Exception):
     pass
 
 
-class ScifloDbTable(object):
+class ScifloDbTable:
     """Sciflo database table class."""
 
     def __init__(self, location, xmlSchema):
@@ -245,7 +245,7 @@ class ScifloDbTable(object):
                 raise ScifloDbTableError("Unknown column type: %s" % typ)
 
             # add col string for class
-            colStr = "    %s = %s(" % (id, colClass)
+            colStr = "    {} = {}(".format(id, colClass)
             colArgsList = []
             if alternateID == True:
                 colArgsList.append("alternateID=True")

--- a/sciflo/db/store.py
+++ b/sciflo/db/store.py
@@ -17,7 +17,7 @@ class StoreError(Exception):
     pass
 
 
-class Store(object):
+class Store:
     """Store base class."""
 
     def __init__(self, name, fieldsList):
@@ -197,7 +197,7 @@ class Store(object):
 
         # print info
         print(sep)
-        print(("Name: %s" % self._name))
+        print("Name: %s" % self._name)
         print(("Fields:", self._fieldsList))
         print(sep3)
 

--- a/sciflo/db/storeConfig.py
+++ b/sciflo/db/storeConfig.py
@@ -17,7 +17,7 @@ class StoreConfigError(Exception):
     pass
 
 
-class StoreConfig(object):
+class StoreConfig:
     """Class representing the configuration for a Store object."""
 
     def __init__(self, storeType, storeName, storeFieldsList, *args, **kargs):

--- a/sciflo/event/PersistentDictServer.py
+++ b/sciflo/event/PersistentDictServer.py
@@ -1,4 +1,3 @@
-
 from twisted.internet import reactor
 from twisted.internet.protocol import Factory
 from twisted.protocols.basic import LineReceiver

--- a/sciflo/event/event.py
+++ b/sciflo/event/event.py
@@ -85,7 +85,7 @@ immediately synched to disk.
     def insert(key, data):
         if key in self.dic:
             raise RuntimeError(
-                'Persistent dict %s already has key: %s' % (self.path, key))
+                'Persistent dict {} already has key: {}'.format(self.path, key))
         if self.lock():
             self.dic.close()
             dic = shelve.open(self.path, flag='r', writeback=False, *options)
@@ -98,7 +98,7 @@ immediately synched to disk.
     def delete(key):
         if key not in self.dic:
             raise RuntimeError(
-                'Persistent dict %s: attempt to delte missing key: %s' % (self.path, key))
+                'Persistent dict {}: attempt to delte missing key: {}'.format(self.path, key))
         if self.lock():
             del self.dic[key]
             self.dic.close()
@@ -114,7 +114,7 @@ immediately synched to disk.
                 return True
             except:
                 os.sleep(1)
-        raise RuntimeError('Cannot acquire lock %s to update persistent dict %s' % (
+        raise RuntimeError('Cannot acquire lock {} to update persistent dict {}'.format(
             self.lockFile, self.path))
 
     def unlock():

--- a/sciflo/event/pdict.py
+++ b/sciflo/event/pdict.py
@@ -195,13 +195,13 @@ The client only has four useful methods:  ping, get, delete, insert.
         self.soc = self._openLocalSocket(self.port)
         if not self.ping():
             raise PersistentDictClientException(
-                'Error, server for %s on port %s does not return ping' % (dictName, self.port))
+                'Error, server for {} on port {} does not return ping'.format(dictName, self.port))
 
     def close(self):
         self.soc.close()
         if DEBUG:
-            print(('PersistentDictClient: Closed socket connection to dictName, port: %s, %d' % (
-                self.dictName, self.port)))
+            print('PersistentDictClient: Closed socket connection to dictName, port: %s, %d' % (
+                self.dictName, self.port))
 
     def ping(self):
         """Ping server to ensure it's alive."""
@@ -216,7 +216,7 @@ The client only has four useful methods:  ping, get, delete, insert.
         cmd = 'get' + NNL + key + NNL
         try:
             soc.sendall(cmd)
-        except socket.error as msg:
+        except OSError as msg:
             soc.close()
             raise PersistentDictClientException(
                 'Error, cannot send to socket: %s' % cmd)
@@ -227,7 +227,7 @@ The client only has four useful methods:  ping, get, delete, insert.
                 data += soc.recv(self.bufsize)
                 if DEBUG:
                     print(('Got data:', data))
-            except socket.error as msg:
+            except OSError as msg:
                 soc.close()
                 raise PersistentDictClientException(
                     'Error, no data received from socket, sent: %s' % cmd)
@@ -271,10 +271,10 @@ The client only has four useful methods:  ping, get, delete, insert.
             soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             soc.connect(('127.0.0.1', port))
             soc.settimeout(self.timeout)
-        except socket.error as e:
+        except OSError as e:
             soc.close()
             print(
-                ('PersistentDictClient: Error, cannot connect socket to local port: %s' % port))
+                'PersistentDictClient: Error, cannot connect socket to local port: %s' % port)
             raise e
         return soc
 
@@ -285,16 +285,16 @@ The client only has four useful methods:  ping, get, delete, insert.
             cmd += NNL
         try:
             soc.sendall(cmd)
-        except socket.error as msg:
+        except OSError as msg:
             soc.close()
             raise RuntimeError(
                 'PersistentDictClient: Error, cannot send to socket: %s' % cmd)
         try:
             data = soc.recv(self.bufsize)
-        except socket.error as e:
+        except OSError as e:
             soc.close()
             print(
-                ('PersistentDictClient: Error, no data received from socket, sent: %s' % cmd))
+                'PersistentDictClient: Error, no data received from socket, sent: %s' % cmd)
             raise e
         data = data[-len(NNL):]
         if data == OkMsg:
@@ -365,25 +365,25 @@ def startPersistentDictServer():
 
 def testClientSimple():
     dic = PersistentDict("Test")
-    print((dic['foo']))
+    print(dic['foo'])
     del dic['foo']
     dic['you'] = 'tube'
-    print((dic['you']))
+    print(dic['you'])
     del dic
 
 
 def testClient():
     dic = PersistentDict("EventStore")
-    print((len(dic)))
-    print((dic['foo']))
+    print(len(dic))
+    print(dic['foo'])
     dic['foo'] = 'bar'
     dic['bush'] = 'sucks'
     dic['fool'] = 'no money'
-    print((dic['foo']))
+    print(dic['foo'])
     del dic['foo']
     dic['you'] = 'tube'
-    print((dic['you']))
-    print((len(dic)))
+    print(dic['you'])
+    print(len(dic))
 
 
 def main():

--- a/sciflo/event/testDbshelve.py
+++ b/sciflo/event/testDbshelve.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 from bsddb import dbshelve
@@ -17,7 +16,7 @@ def test(filename):
         key = abc+'%4.4d' % i
 #        print key
         db[key] = val1
-    print((clock() - t0))
+    print(clock() - t0)
 
     t0 = clock()
     for i in range(10000):
@@ -26,7 +25,7 @@ def test(filename):
         tmp = db[key]
         db[key] = val2
         tmp = db[key]
-    print((clock() - t0))
+    print(clock() - t0)
 
     t0 = clock()
     for i in range(10000):
@@ -39,7 +38,7 @@ def test(filename):
 #            db.sync()
         except:
             pass
-    print((clock() - t0))
+    print(clock() - t0)
 
 #    db.close()
 

--- a/sciflo/event/testPDict.py
+++ b/sciflo/event/testPDict.py
@@ -1,4 +1,3 @@
-
 import sys
 import os
 from bsddb import dbshelve

--- a/sciflo/grid/adapt.py
+++ b/sciflo/grid/adapt.py
@@ -252,7 +252,7 @@ class ConversionRegistry:
             warn('Unregistered conversion %s: %s -> %s' %
                  (str(conversionFn), inType, outType))
         try:
-            self.convert[inType][outType].remove((conversionFn))
+            self.convert[inType][outType].remove(conversionFn)
         except:
             warn('Attempt to unregister a conversion function that is not registered: '
                  '%s: %s -> %s' % (str(conversionFn), inType, outType))
@@ -305,7 +305,7 @@ class ConversionRegistry:
         via some candidate chain.
         """
         if verbose:
-            warn('Seeking chain for conversion %s -> %s' % (inType, outType))
+            warn('Seeking chain for conversion {} -> {}'.format(inType, outType))
         typesSeen.add(inType)
         for ty in self.convert[inType]:
             if ty in typesSeen:
@@ -410,7 +410,7 @@ if __name__ == '__main__':
 
     def xml2ListOfDict(xml):
         """Convert an xmlDoc string to a python list of dictionaries."""
-        return [dict([(child.tag, child.text) for child in elt]) for elt in XML(xml)]
+        return [{child.tag: child.text for child in elt} for elt in XML(xml)]
 
     def xml2ListOfDict_Tutorial(xml):
         """Same as previous function, but the hard (wrong) way."""
@@ -425,7 +425,7 @@ if __name__ == '__main__':
 
     def xml2ListOfDict_2step(xml):
         """Same conversion but now input xml must be an ElementTree."""
-        return [dict([(child.tag, child.text) for child in elt]) for elt in xml]
+        return [{child.tag: child.text for child in elt} for elt in xml]
 
     #adapt.registerConversion('str', 'py:ListOfDict', xml2ListOfDict)
     # Register only single-step conversion to test seek of 2-step conversion chain:

--- a/sciflo/grid/annotatedDoc.py
+++ b/sciflo/grid/annotatedDoc.py
@@ -16,7 +16,7 @@ class AnnotatedDocError(Exception):
     pass
 
 
-class AnnotatedDoc(object):
+class AnnotatedDoc:
     def __init__(self, sflDoc, outputDir):
         """Constructor."""
 
@@ -139,7 +139,7 @@ class AnnotatedDoc(object):
         """Add info for a processing step that finished."""
 
         try:
-            with open(pidFile, 'r') as f:
+            with open(pidFile) as f:
                 pid = f.read()
         except:
             pid = 'unknown'

--- a/sciflo/grid/callback.py
+++ b/sciflo/grid/callback.py
@@ -32,7 +32,7 @@ def getCallback(config):
     print "&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&"
     '''
     if not isinstance(config, tuple) and not isinstance(config, list):
-        raise RuntimeError("Argument must be a tuple, list, or ArrayType.  Got %s %s." % (
+        raise RuntimeError("Argument must be a tuple, list, or ArrayType.  Got {} {}.".format(
             type(config), config))
 
     # get type
@@ -56,7 +56,7 @@ def getCallback(config):
     return callbackObj
 
 
-class ScifloCallback(object):
+class ScifloCallback:
     """Base class for ScifloCallback classes."""
 
     def __init__(self, args=[]):
@@ -85,7 +85,7 @@ class FunctionCallback(ScifloCallback):
         """Constructor."""
 
         # call super
-        super(FunctionCallback, self).__init__(args)
+        super().__init__(args)
 
         # arg is function call
         if len(self._args) == 1:

--- a/sciflo/grid/config.py
+++ b/sciflo/grid/config.py
@@ -115,7 +115,7 @@ def getScheduleConfigFromConfiguration(file=None):
             "Unknown scheduleStoreType %s in configuration." % scheduleStoreType)
 
 
-class GridServiceConfig(object):
+class GridServiceConfig:
     """Class representing the soap grid service configuration for this node.
     """
 
@@ -144,7 +144,7 @@ class GridServiceConfig(object):
             './/{%s}cancelWorkUnitMethod/{%s}exposedName' %
             (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
         self._callbackMethod = parserObj.getMandatoryParameterViaXPath(
-            './/{%s}callbackMethod/{%s}exposedName' % (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
+            './/{{{}}}callbackMethod/{{{}}}exposedName'.format(SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
         self._addWorkUnitPythonMethod = parserObj.getMandatoryParameterViaXPath(
             './/{%s}addWorkUnitMethod/{%s}pythonFunction' %
             (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
@@ -155,7 +155,7 @@ class GridServiceConfig(object):
             './/{%s}cancelWorkUnitMethod/{%s}pythonFunction' %
             (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
         self._callbackPythonMethod = parserObj.getMandatoryParameterViaXPath(
-            './/{%s}callbackMethod/{%s}pythonFunction' % (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
+            './/{{{}}}callbackMethod/{{{}}}pythonFunction'.format(SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
         self._workUnitWorkDir = parserObj.getMandatoryParameter(
             'workUnitRootWorkDir')
 
@@ -166,10 +166,10 @@ class GridServiceConfig(object):
             prot = 'http'
 
         # grid base url
-        self._gridBaseUrl = "%s://%s:%s" % (prot, getfqdn(), self._gridPort)
+        self._gridBaseUrl = "{}://{}:{}".format(prot, getfqdn(), self._gridPort)
 
         # callback wsdl
-        self._gridWsdl = "%s/wsdl?%s" % (self._gridBaseUrl,
+        self._gridWsdl = "{}/wsdl?{}".format(self._gridBaseUrl,
                                          self._gridNamespace)
 
     def getWorkUnitWorkDir(self):

--- a/sciflo/grid/doc.py
+++ b/sciflo/grid/doc.py
@@ -43,7 +43,7 @@ def translatePrefixes(xpath, namespaces):
                 elts.append(namespaces[prefix] + tag)
             else:
                 raise RuntimeError(
-                    'Unknown namespace with prefix %s in XPath: %s' % (prefix, xpath))
+                    'Unknown namespace with prefix {} in XPath: {}'.format(prefix, xpath))
         else:
             elts.append(elt)
     return '/'.join(elts)
@@ -56,7 +56,7 @@ def ns(xpath): return translatePrefixes(xpath, namespaces=NS)
 SCIFLO_SCHEMA_XML = resource_string(__name__, 'sciflo.xsl').decode()
 
 
-class WorkUnitConfig(object):
+class WorkUnitConfig:
     """Class containing work unit configuration."""
 
     def __init__(self, procCount, id, typ, call, args, stageFiles=[],
@@ -116,7 +116,7 @@ class UnresolvedArgumentError(Exception):
     pass
 
 
-class UnresolvedArgument(object):
+class UnresolvedArgument:
     """Class representing an unresolved argument."""
 
     def __init__(self, procId, outputIndex=None):
@@ -157,7 +157,7 @@ class DocumentArgsList(list):
 
     def __init__(self, docStr, *args, **kwargs):
         self.docStr = docStr
-        super(DocumentArgsList, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class ScifloError(Exception):
@@ -165,7 +165,7 @@ class ScifloError(Exception):
     pass
 
 
-class Sciflo(object):
+class Sciflo:
     """Class representing a SciFlo document."""
     # Class attributes
     typeAttribute = 'type'
@@ -247,7 +247,7 @@ class Sciflo(object):
                 o = doc.find(ns('sf:flow/sf:inputs/%s' % k))
                 if o is None:
                     raise ScifloError(
-                        "Unknown global input %s (%s)." % (k, self._inputDict[k]))
+                        "Unknown global input {} ({}).".format(k, self._inputDict[k]))
                 o.text = str(self._inputDict[k])
 
         # Make sure that global output tagnames were not used more than once
@@ -350,7 +350,7 @@ class Sciflo(object):
             if job_queue is None:
                 raise ScifloError(
                     "You must specify 'job_queue' attribute for binding type 'map'.")
-            call = '%s|%s|%s' % (val, job_queue, async_flag)
+            call = '{}|{}|{}'.format(val, job_queue, async_flag)
             return (wuType, endpoint, call)
         # parallel python
         elif typ == 'parallel':
@@ -361,7 +361,7 @@ class Sciflo(object):
             if job_queue is None:
                 raise ScifloError(
                     "You must specify 'job_queue' attribute for binding type 'parallel'.")
-            call = '%s|%s|%s' % (val, job_queue, async_flag)
+            call = '{}|{}|{}'.format(val, job_queue, async_flag)
             return (wuType, endpoint, call)
         # handle python function, soap, binary, script, xquery, and bindings
         else:
@@ -386,7 +386,7 @@ class Sciflo(object):
                 call = method
             else:
                 raise ScifloError(
-                    "Failed to parse %s binding: %s" % (typ, val))
+                    "Failed to parse {} binding: {}".format(typ, val))
         # import and eval python if debugMode
         if self._debugMode:
             sys.path.insert(1, getUserPubPackagesDir())
@@ -395,14 +395,14 @@ class Sciflo(object):
                 try:
                     getFunction(call)
                 except Exception as e:
-                    print(('''Got exception trying to load module in debug mode.  \
-This module may be a staged file or bundle: %s''' % str(e)))
+                    print('''Got exception trying to load module in debug mode.  \
+This module may be a staged file or bundle: %s''' % str(e))
             elif wuType == 'inline python function':
                 try:
                     eval(call)
                 except Exception as e:
                     print(
-                        ('''Got exception trying to eval inline python in debug mode: %s''' % str(e)))
+                        '''Got exception trying to eval inline python in debug mode: %s''' % str(e))
         isBundle(endpoint)
         return (wuType, endpoint, call)
 
@@ -1141,7 +1141,7 @@ This module may be a staged file or bundle: %s''' % str(e)))
                     if resolvingProcOutputIndex is None:
                         resolvingProcOutputIndex = '0'
                     inputsElt[i].set('from', 'process')
-                    inputsElt[i].set('val', '%s:%s' % (
+                    inputsElt[i].set('val', '{}:{}'.format(
                         resolvingProcId, resolvingProcOutputIndex))
                 else:
                     if i in wuConfig.argIdxsResolvedGloballyDict:
@@ -1171,7 +1171,7 @@ This module may be a staged file or bundle: %s''' % str(e)))
             resProcOutputIdx = resProcConfig.getOutputIndex()
             if resProcOutputIdx is None:
                 resProcOutputIdx = '0'
-            outputElt.set('val', '%s:%s' % (resProcId, resProcOutputIdx))
+            outputElt.set('val', '{}:{}'.format(resProcId, resProcOutputIdx))
             globalOutputIdx += 1
 
         self.fullDot = fullDotFlowChartFromDependencies(rtElt)

--- a/sciflo/grid/executor.py
+++ b/sciflo/grid/executor.py
@@ -61,15 +61,15 @@ def scifloInfo(info=None, **kargs):
     return info
 
 
-class WuReady(object):
+class WuReady:
     def __init__(self, val): self.val = val
 
 
-class PostExecResult(object):
+class PostExecResult:
     def __init__(self, val): self.val = val
 
 
-class NoResult(object):
+class NoResult:
     pass
 
 
@@ -96,14 +96,14 @@ class NoDaemonContext(type(multiprocessing.get_context())):
 class ScifloPool(multiprocessing.pool.Pool):
     def __init__(self, *args, **kwargs):
         kwargs['context'] = NoDaemonContext()
-        super(ScifloPool, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
 class ScifloExecutorError(Exception):
     pass
 
 
-class ScifloExecutor(object):
+class ScifloExecutor:
     """Execution engine for sciflo."""
 
     def __init__(self, sflString, args={}, workers=4, workerTimeout=None,
@@ -199,7 +199,7 @@ class ScifloExecutor(object):
                 self.pdict = PersistentDict(self.cacheName, pickleVals=True)
             except Exception as e:
                 self.logger.debug("Got exception trying to get PersistentDict \
-for sciflo '%s': %s.  No cache will be used." % (self.scifloName, e),
+for sciflo '{}': {}.  No cache will be used.".format(self.scifloName, e),
                                   extra={'id': self.scifloid})
                 self.cacheName = None
                 self.pdict = None
@@ -224,7 +224,7 @@ for sciflo '%s': %s.  No cache will be used." % (self.scifloName, e),
             if self.publicize:
                 self.baseUrl = self.gsc.getGridBaseUrl()
             else:
-                self.baseUrl = "file://%s%s" % (getfqdn(), self.workDir)
+                self.baseUrl = "file://{}{}".format(getfqdn(), self.workDir)
         self.ubt = UrlBaseTracker(self.workDir, self.baseUrl)
         if self.publicize:
             self.publicizeUbt = self.ubt
@@ -249,7 +249,7 @@ for sciflo '%s': %s.  No cache will be used." % (self.scifloName, e),
                                      configDict=self.configDict)
                 except Exception as e:
                     raise ScifloExecutorError("Encountered error calling \
-getWorkUnit(): %s\n%s" % (str(e), getTb()))
+getWorkUnit(): {}\n{}".format(str(e), getTb()))
                 wuid = wu.getWuid()
                 appRes = WuReady(wu)
                 # update info in work unit json for monitoring
@@ -424,8 +424,8 @@ getWorkUnit(): %s\n%s" % (str(e), getTb()))
                 resolvingRes = rewriteFile
             return resolvingRes
         except Exception as e:
-            self.logger.debug("Got error in resolveArg() method for '%s' in \
-sciflo '%s': %s\n%s" % (resolvingId, self.scifloName, str(e), getTb()),
+            self.logger.debug("Got error in resolveArg() method for '{}' in \
+sciflo '{}': {}\n{}".format(resolvingId, self.scifloName, str(e), getTb()),
                 extra={'id': self.scifloid})
             raise
 
@@ -520,8 +520,8 @@ sciflo '%s': %s\n%s" % (resolvingId, self.scifloName, str(e), getTb()),
         try:
             linkFile(workDir, linkDir)
         except Exception as e:
-            self.logger.debug("Got error trying to link work dir '%s' to '%s' \
-for '%s' in sciflo '%s': %s\n%s" % (workDir, linkDir, procId, self.scifloName,
+            self.logger.debug("Got error trying to link work dir '{}' to '{}' \
+for '{}' in sciflo '{}': {}\n{}".format(workDir, linkDir, procId, self.scifloName,
                                     str(e), getTb()), extra={'id': self.scifloid})
 
         # lookup cache?
@@ -625,8 +625,8 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
             self.pool.close()
             self.pool.join()
             endTime = time.time()
-            self.logger.debug("done.  Shutdown took %s seconds for sciflo \
-'%s'." % ((endTime - startTime), self.scifloName), extra={'id': self.scifloid})
+            self.logger.debug("done.  Shutdown took {} seconds for sciflo \
+'{}'.".format((endTime - startTime), self.scifloName), extra={'id': self.scifloid})
 
             # update sciflo info
             self.updateScifloInfo(endTime=time.time(), status=finalStatus,
@@ -673,7 +673,7 @@ in runLockedFunction() for sciflo '%s': %s\n%s" %
             runLockedFunction(self.lock, self.handle, callbackResult)
         except Exception as e:
             emessage = "Error running callback in runLockedFunction() for \
-sciflo '%s':%s\n%s" % (self.scifloName, str(e), getTb())
+sciflo '{}':{}\n{}".format(self.scifloName, str(e), getTb())
             self.logger.debug(emessage, extra={'id': self.scifloid})
             self.executionError = ('callback', ScifloExecutorError(emessage),
                                    getTb())
@@ -681,7 +681,7 @@ sciflo '%s':%s\n%s" % (self.scifloName, str(e), getTb())
                 runFuncWithRetries(5, self.event.set)
             except Exception as e:
                 emessage = "Got error setting event from callback() exception \
-in sciflo '%s': %s\n%s" % (self.scifloName, str(e), getTb())
+in sciflo '{}': {}\n{}".format(self.scifloName, str(e), getTb())
                 self.logger.debug(emessage, extra={'id': self.scifloid})
                 raise ScifloExecutorError(emessage)
 
@@ -726,7 +726,7 @@ with status '%s'.  Handling result." %
         f = open(info['executionLog'])
         wuLog = f.read()
         f.close()
-        self.logger.debug("Execution log for '%s': %s" % (
+        self.logger.debug("Execution log for '{}': {}".format(
             procId, wuLog), extra={'id': self.scifloid})
 
         # add provenance info for workUnit execution started
@@ -848,7 +848,7 @@ for handleResult() for procId '%s' in sciflo '%s': %s.  No cache will be used."
                     pePklFile = pdict[postExecHex]
                 except Exception as e:
                     self.logger.debug("Got error trying to retrieve cached \
-post execution for '%s' in sciflo '%s': %s\n%s" % (procId, self.scifloName,
+post execution for '{}' in sciflo '{}': {}\n{}".format(procId, self.scifloName,
                                                    str(e), getTb()),
                                       extra={'id': self.scifloid})
                     pePklFile = None
@@ -859,8 +859,8 @@ post execution for '%s' in sciflo '%s': %s\n%s" % (procId, self.scifloName,
 
             # otherwise just run it
             if postExecResult is None:
-                self.logger.debug("Running post execution for '%s' in sciflo \
-'%s': %s" % (procId, self.scifloName, (resIdx, funcStr)),
+                self.logger.debug("Running post execution for '{}' in sciflo \
+'{}': {}".format(procId, self.scifloName, (resIdx, funcStr)),
                     extra={'id': self.scifloid})
                 try:
                     postExecHandler = PostExecutionHandler(resIdx, funcStr,
@@ -887,11 +887,11 @@ post execution results for '%s' to cache under '%s' in sciflo '%s': %s\n%s" %
                 except Exception as e:
                     postExecResult = PostExecResult(e)
                     self.logger.debug("Got error running post execution for \
-'%s' in sciflo '%s': %s" % (procId, self.scifloName, res),
+'{}' in sciflo '{}': {}".format(procId, self.scifloName, res),
                         extra={'id': self.scifloid})
             else:
                 self.logger.debug("Using cached post execution result for \
-'%s' in sciflo '%s': %s" % (procId, self.scifloName, (resIdx, funcStr)),
+'{}' in sciflo '{}': {}".format(procId, self.scifloName, (resIdx, funcStr)),
                     extra={'id': self.scifloid})
 
             # set it; not if we need to publicize
@@ -903,8 +903,8 @@ post execution results for '%s' to cache under '%s' in sciflo '%s': %s\n%s" %
                 self.postExecResultsDict[procId][i] = \
                     getAbsPathForResultFiles(
                         postExecResult.val, dir=info['workDir'])
-            self.logger.debug("Finished post execution for '%s' in sciflo '%s':\
- %s" % (procId, self.scifloName, (resIdx, funcStr)),
+            self.logger.debug("Finished post execution for '{}' in sciflo '{}':\
+ {}".format(procId, self.scifloName, (resIdx, funcStr)),
                 extra={'id': self.scifloid})
 
         # write result to annotated doc and set to done;
@@ -935,12 +935,12 @@ post execution results for '%s' to cache under '%s' in sciflo '%s': %s\n%s" %
         if pdict is not None and info['workerStatus'] == doneStatus:
             try:
                 updatePdict(pdict, self.hexDict[procId], info['jsonFile'])
-                self.logger.debug("Wrote info for '%s' to cache under '%s' \
-in sciflo '%s'." % (procId, self.hexDict[procId], self.scifloName),
+                self.logger.debug("Wrote info for '{}' to cache under '{}' \
+in sciflo '{}'.".format(procId, self.hexDict[procId], self.scifloName),
                     extra={'id': self.scifloid})
             except Exception as e:
                 self.logger.debug("Got exception trying to write info for \
-'%s' to cache under '%s' in sciflo '%s': %s\n%s" % (procId,
+'{}' to cache under '{}' in sciflo '{}': {}\n{}".format(procId,
                                                     self.hexDict[procId], self.scifloName, str(e), getTb()),
                                   extra={'id': self.scifloid})
 
@@ -973,16 +973,16 @@ in sciflo '%s'." % (procId, self.hexDict[procId], self.scifloName),
             self.updateStatus('WorkUnit status for "%s": %s' %
                               (procId, status), info)
         except Exception as e:
-            self.logger.debug("Got error in handleError() for '%s' in sciflo \
-'%s': %s\n%s" % (procId, self.scifloName, str(e), getTb()),
+            self.logger.debug("Got error in handleError() for '{}' in sciflo \
+'{}': {}\n{}".format(procId, self.scifloName, str(e), getTb()),
                 extra={'id': self.scifloid})
 
         # set event
         try:
             self.event.set()
-        except IOError as e:
+        except OSError as e:
             self.logger.debug("Got IOError setting event from handleError() \
-for '%s' in sciflo '%s': %s\n%s" % (procId, self.scifloName, str(e), getTb()),
+for '{}' in sciflo '{}': {}\n{}".format(procId, self.scifloName, str(e), getTb()),
                               extra={'id': self.scifloid})
 
     def updateGlobalOutputs(self, procId):
@@ -1057,7 +1057,7 @@ def _runSciflo(sflStr, args={}, workers=4, timeout=None, workDir=None,
         result = s.output
     except Exception as e:
         result = e
-        print((getTb()))
+        print(getTb())
 
     notifyByEmail(emailNotify, result, s)
     return result
@@ -1112,6 +1112,6 @@ def notifyByEmail(address, result, executor):
 
             send_email(getuser(), [address], [], title, message)
         except Exception as e:
-            print(("Got error trying to notify %s by email: %s" %
-                   (address, getTb())))
+            print("Got error trying to notify %s by email: %s" %
+                   (address, getTb()))
             pass

--- a/sciflo/grid/funcs.py
+++ b/sciflo/grid/funcs.py
@@ -179,7 +179,7 @@ def workUnitWorker(wu, cacheName, timeout):
                 pdict = PersistentDict(cacheName, pickleVals=True)
             except Exception as e:
                 WORKER_LOGGER.debug("Caught exception trying to create pdict \
-for '%s': %s\n%s" % (procId, str(e), getTb()), extra={'id': wuid})
+for '{}': {}\n{}".format(procId, str(e), getTb()), extra={'id': wuid})
                 pdict = None
 
         # if cache was not found or if it was and there was no cached value,
@@ -188,8 +188,8 @@ for '%s': %s\n%s" % (procId, str(e), getTb()), extra={'id': wuid})
             try:
                 jsonFile = pdict[hex]
             except Exception as e:
-                WORKER_LOGGER.debug("Caught exception for '%s' trying to query \
-pdict with key '%s': %s\n%s" % (procId, hex, str(e), getTb()),
+                WORKER_LOGGER.debug("Caught exception for '{}' trying to query \
+pdict with key '{}': {}\n{}".format(procId, hex, str(e), getTb()),
                     extra={'id': wuid})
                 jsonFile = None
             if jsonFile is not None and os.path.exists(jsonFile):
@@ -199,8 +199,8 @@ pdict with key '%s': %s\n%s" % (procId, hex, str(e), getTb()),
             else:
                 info = None
             if info is not None and info['status'] == doneStatus:
-                WORKER_LOGGER.debug("Returning cached results for '%s' under \
-key '%s'." % (procId, hex), extra={'id': wuid})
+                WORKER_LOGGER.debug("Returning cached results for '{}' under \
+key '{}'.".format(procId, hex), extra={'id': wuid})
                 if not os.path.exists(wu._logFile):
                     with open(wu._logFile, 'w') as logFh:
                         logFh.write("This work unit's result was retrieved from a \
@@ -251,7 +251,7 @@ previously cached execution: %s" % info['executionLog'])
         gotError = False
     except Empty as e:
         res = (ExecuteWorkUnitTimeoutError("Got timeout error executing work \
-unit %s: %s" % (procId, e)), None)
+unit {}: {}".format(procId, e)), None)
     except Exception as e:
         res = (e, getTb())
     WORKER_LOGGER.debug("Finished waiting on process for '%s'." % procId,

--- a/sciflo/grid/gridFuncs.py
+++ b/sciflo/grid/gridFuncs.py
@@ -40,20 +40,20 @@ def getGridSoapMethods(protocol, addr, port, ns, configFile=None):
     #    proxy=getGSISOAPProxy("https://%s:%s" % (addr, port), ns)
 
     if protocol == 'ssl':
-        proxy = SOAPProxy("https://%s:%s" % (addr, port), ns)
+        proxy = SOAPProxy("https://{}:{}".format(addr, port), ns)
     elif protocol == 'http':
-        proxy = SOAPProxy("http://%s:%s" % (addr, port), ns)
+        proxy = SOAPProxy("http://{}:{}".format(addr, port), ns)
     else:
         raise RuntimeError("Failed to recognize protocol type: %s" % protocol)
 
     # get add, cancel and query workunit methodnames from configuration file
     parserObj = ScifloConfigParser(configFile)
     addStr = parserObj.getMandatoryParameterViaXPath(
-        './/{%s}addWorkUnitMethod/{%s}exposedName' % (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
+        './/{{{}}}addWorkUnitMethod/{{{}}}exposedName'.format(SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
     queryStr = parserObj.getMandatoryParameterViaXPath(
-        './/{%s}queryWorkUnitMethod/{%s}exposedName' % (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
+        './/{{{}}}queryWorkUnitMethod/{{{}}}exposedName'.format(SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
     cancelStr = parserObj.getMandatoryParameterViaXPath(
-        './/{%s}cancelWorkUnitMethod/{%s}exposedName' % (SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
+        './/{{{}}}cancelWorkUnitMethod/{{{}}}exposedName'.format(SCIFLO_NAMESPACE, SCIFLO_NAMESPACE))
 
     # add work unit method
     addWorkUnitMethod = eval("proxy.%s" % addStr)
@@ -114,7 +114,7 @@ def getGridLocalMethods(configFile, debug=False):
     return (addWorkUnitMethod, cancelWorkUnitMethod, queryMethod)
 
 
-class GridFunction(object):
+class GridFunction:
     """Base class for grid functions."""
 
     def __init__(self, func, configFile=None):
@@ -129,4 +129,4 @@ class GridFunction(object):
 
 class WorkUnitCallback(GridFunction):
     def __init__(self, configFile=None):
-        super(WorkUnitCallback, self).__init__(workUnitCallback, configFile)
+        super().__init__(workUnitCallback, configFile)

--- a/sciflo/grid/manager.py
+++ b/sciflo/grid/manager.py
@@ -85,7 +85,7 @@ class WorkUnitExecutionHandlerError(Exception):
     pass
 
 
-class WorkUnitExecutionHandler(object):
+class WorkUnitExecutionHandler:
     """WorkUnitExecutionHandler base class."""
 
     def __init__(self, workUnitOwner, workUnitType, workUnitCall, workUnitArgs, wuStoreConfig,
@@ -352,7 +352,7 @@ class WorkUnitExecutionHandler(object):
             emessage += etb
             self._result = e
 
-            print(("Encountered exception during staging: %s" % emessage))
+            print("Encountered exception during staging: %s" % emessage)
 
             # set status to exception and write error
             self._wuHexDigest = None
@@ -429,7 +429,7 @@ class WorkUnitExecutionHandler(object):
                 emessage += etb
                 self._result = e
 
-                print(("Encountered exception during post execution: %s" % emessage))
+                print("Encountered exception during post execution: %s" % emessage)
 
                 # set status to exception and write error
                 self._wuHexDigest = None
@@ -490,7 +490,7 @@ class WorkUnitDied(Exception):
     pass
 
 
-class WorkUnitManager(object):
+class WorkUnitManager:
     """Class that manages the WorkUnitExecutionHandler object."""
 
     def __init__(self, owner, type, call, args, storeConfig, workRootDir, stageFiles=None,

--- a/sciflo/grid/postExecution.py
+++ b/sciflo/grid/postExecution.py
@@ -143,7 +143,7 @@ class PostExecutionHandlerError(Exception):
     pass
 
 
-class PostExecutionHandler(object):
+class PostExecutionHandler:
     """Class that handles the execution of a conversion function on the
     results of a work unit."""
 

--- a/sciflo/grid/storeHandler.py
+++ b/sciflo/grid/storeHandler.py
@@ -42,7 +42,7 @@ class WorkUnitStoreHandlerError(Exception):
     pass
 
 
-class WorkUnitStoreHandler(object):
+class WorkUnitStoreHandler:
     """WorkUnitStoreHandler base class.  Work unit metadata stored in the WorkUnitStore
     include: id, hex digest, owner, status, type, call, args, work directory, entry time,
     start time, end time, result, exception message, post execution results, cancelFlag,
@@ -488,7 +488,7 @@ class ScheduleStoreHandlerError(Exception):
     pass
 
 
-class ScheduleStoreHandler(object):
+class ScheduleStoreHandler:
     """ScheduleStoreHandler base class."""
 
     def __init__(self, storeConfig):
@@ -763,7 +763,7 @@ class ScheduleStoreHandler(object):
                 return wuConfigIds[0]
 
         raise ScheduleStoreHandlerError(
-            "Cannot find procId %s in scifloid %s." % (procId, scifloId))
+            "Cannot find procId {} in scifloid {}.".format(procId, scifloId))
 
     def getScifloidInfo(self, scifloId, fields):
         """Return sorted list of dicts containing field info.  Sorted by

--- a/sciflo/grid/utils.py
+++ b/sciflo/grid/utils.py
@@ -174,7 +174,7 @@ def updatePdict(pdict, k, v):
         if pdict is not None:
             pdict[k] = v
     except Exception as e:
-        print(("Got exception trying to update pdict key '%s': %s" % (k, str(e))))
+        print("Got exception trying to update pdict key '{}': {}".format(k, str(e)))
 
 
 def runFuncWithRetriesAndSleep(retries, sleep, f, *args, **kargs):
@@ -185,8 +185,8 @@ def runFuncWithRetriesAndSleep(retries, sleep, f, *args, **kargs):
         try:
             return f(*args, **kargs)
         except Exception as e:
-            print(("Got error in runFuncWithRetriesAndSleep() on try %i for \
-function '%s': %s\n%s" % (i + 1, str(f), str(e), getTb())))
+            print("Got error in runFuncWithRetriesAndSleep() on try %i for \
+function '%s': %s\n%s" % (i + 1, str(f), str(e), getTb()))
         time.sleep(sleep)
     raise e
 
@@ -206,8 +206,8 @@ def runLockedFunction(mutex, f, *args, **kargs):
     except Exception as e:
         gotError = True
         res = e
-        print(("Got error in runLockedFunction() for function '%s': %s\n%s" %
-               (str(f), str(e), getTb())))
+        print("Got error in runLockedFunction() for function '%s': %s\n%s" %
+               (str(f), str(e), getTb()))
     finally:
         runFuncWithRetriesAndSleep(3, 1, mutex.release)
     if gotError:
@@ -275,7 +275,7 @@ def getArgsString(args):
         keys = list(args.keys())
         keys.sort()
         for key in keys:
-            retString += "%s|%s" % (key, getArgsString(args[key]))
+            retString += "{}|{}".format(key, getArgsString(args[key]))
         return retString
     else:
         return str(args)
@@ -297,7 +297,7 @@ def generateWorkUnitHexDigest(owner, type, call, args, stageFiles, postExecIds):
     """Return a md5 hex digest of the objects passed in."""
 
     # get md5 hex digest
-    return hashlib.md5("%s %s %s %s %s %s" % (owner, type, call, getArgsString(args),
+    return hashlib.md5("{} {} {} {} {} {}".format(owner, type, call, getArgsString(args),
                                               getStageFilesString(
                                                   getListFromUnknownObject(stageFiles)),
                                               getArgsString(postExecIds))).hexdigest()
@@ -393,7 +393,7 @@ class StdIOFaker(StringIO):
         return StringIO.write(self, strToWrite)
 
 
-class Tee(object):
+class Tee:
     def __init__(self, stream, *args, **kargs):
         self.stream = stream
         self.file = open(*args, **kargs)
@@ -577,7 +577,7 @@ def fullDotFlowChartFromDependencies(dotInfoElt):
         resOutputId = dotInfoElt.xpath('./processes/process[@id="%s"]/outputs/output' %
                                        resProcId)[resOutputIdx].get('id')
         process2GlobalOutputEdgesList.append(
-            '  %s:%s:e -> %s:w ;' % (resProcId, resOutputId, goElt.get('id')))
+            '  {}:{}:e -> {}:w ;'.format(resProcId, resOutputId, goElt.get('id')))
     globalOutputs = '\n'.join(globalOutputsList)
 
     # get edges

--- a/sciflo/grid/workUnit.py
+++ b/sciflo/grid/workUnit.py
@@ -59,7 +59,7 @@ class WorkUnitError(Exception):
     pass
 
 
-class WorkUnit(object):
+class WorkUnit:
     """Sciflo WorkUnit base class."""
 
     def __init__(self, call, args, workDir, verbose=False, wuid=None,
@@ -109,7 +109,7 @@ class WorkUnit(object):
         userPvtPackagesDir = getUserPvtPackagesDir()
         origEnvPath = os.environ['PATH']
         origSysPath = sys.path
-        os.environ['PATH'] = '.:%s:%s:%s' % (
+        os.environ['PATH'] = '.:{}:{}:{}'.format(
             userPvtPackagesDir, userPubPackagesDir, os.environ['PATH'])
         sys.path.insert(1, userPubPackagesDir)
         sys.path.insert(1, userPvtPackagesDir)
@@ -346,7 +346,7 @@ class RestWorkUnit(WorkUnit):
         f, h = urllib.request.urlretrieve(encodedUrl)
         mimeType = h.gettype()
         mimeMainType, mimeSubType = mimeType.split('/')
-        newFile = '%s.%s' % (os.path.basename(f), mimeSubType)
+        newFile = '{}.{}'.format(os.path.basename(f), mimeSubType)
         shutil.move(f, newFile)
         os.chmod(newFile, 0o644)
         return newFile
@@ -426,7 +426,7 @@ class PostWorkUnit(WorkUnit):
         headersDict = self._args[0]
         postData = self._args[1]
         if self._verbose:
-            print("PostWorkUnit: %s %s %s" % (url, str(headersDict), postData))
+            print("PostWorkUnit: {} {} {}".format(url, str(headersDict), postData))
         return postCall(url, postData, headersDict, self._verbose)
 
 
@@ -441,7 +441,7 @@ class ScifloWorkUnit(WorkUnit):
     def __init__(self, call, args, workDir, verbose=False, wuid=None,
                  procId=None, hexDigest=None, scifloid=None, configDict={}):
 
-        super(ScifloWorkUnit, self).__init__(call, args, workDir, verbose, wuid,
+        super().__init__(call, args, workDir, verbose, wuid,
                                              procId, hexDigest, configDict=configDict)
         if scifloid is None:
             self._scifloid = generateScifloId()
@@ -493,7 +493,7 @@ class ParMapWorkUnit(PythonFunctionWorkUnit):
         else:
             print("No HySDS context JSON found at %s. Proceeding without it." % ctx_file)
 
-        super(ParMapWorkUnit, self).__init__(call, args, workDir, verbose, wuid,
+        super().__init__(call, args, workDir, verbose, wuid,
                                              procId, hexDigest, configDict=configDict)
 
     def _run(self):
@@ -505,7 +505,7 @@ class ParMapWorkUnit(PythonFunctionWorkUnit):
         # get list of jobs
         jobs = []
         if not isinstance(self._args[0], (list, tuple)):
-            raise ParMapWorkUnitError("Invalid type for ParWorkUnit argument 1: %s\n%s" % (
+            raise ParMapWorkUnitError("Invalid type for ParWorkUnit argument 1: {}\n{}".format(
                 type(self._args[0]), self._args[0]))
 
         for i, arg in enumerate(self._args[0]):
@@ -593,9 +593,9 @@ class ParWorkUnit(ParMapWorkUnit):
     def __init__(self, call, args, workDir, verbose=False, wuid=None,
                  procId=None, hexDigest=None, configDict={}):
         args[0] = [args[0]]
-        super(ParWorkUnit, self).__init__(call, args, workDir, verbose, wuid,
+        super().__init__(call, args, workDir, verbose, wuid,
                                           procId, hexDigest, configDict=configDict)
 
     def _run(self):
-        results = super(ParWorkUnit, self)._run()
+        results = super()._run()
         return results[0]

--- a/sciflo/mapreduce/test.py
+++ b/sciflo/mapreduce/test.py
@@ -52,7 +52,7 @@ def create_map_job(startdate, enddate, segmentBy, arg1, arg2, wuid=None, job_num
             # sciflo tracking info
             "_sciflo_wuid": wuid,
             "_sciflo_job_num": job_num,
-            "_command": "/usr/bin/echo {} {} {} {}".format(start.year, start.month, arg1, arg2),
+            "_command": f"/usr/bin/echo {start.year} {start.month} {arg1} {arg2}",
 
             # job params
             "year": start.year,
@@ -88,14 +88,14 @@ def create_reduce_job(results, wuid=None, job_num=None):
 def get_reduce_job_result(result):
     """Test function for processing a reduced job result."""
 
-    print(("got result: {}".format(json.dumps(result, indent=2))))
+    print(f"got result: {json.dumps(result, indent=2)}")
     return result['payload_id']
 
 
 def join_map_jobs(task_ids):
     """Test reduce function that manually joins all mapped jobs."""
 
-    print(("task_ids: {}".format(json.dumps(task_ids, indent=2))))
+    print(f"task_ids: {json.dumps(task_ids, indent=2)}")
     res = GroupResult(id=uuid.uuid4().bytes, results=[
                       AsyncResult(id[0]) for id in task_ids])
     while True:

--- a/sciflo/utils/dataenc.py
+++ b/sciflo/utils/dataenc.py
@@ -732,7 +732,7 @@ def binunleave(data):
 # Included for reference is the bf object and the binary operations as functions.
 
 
-class bf(object):
+class bf:
     """the bf(object) from activestate python cookbook - by Sebastien Keim - Many Thanks
     http://aspn.activestate.com/ASPN/Cookbook/Python/Recipe/113799"""
 

--- a/sciflo/utils/dateutils.py
+++ b/sciflo/utils/dateutils.py
@@ -608,11 +608,11 @@ dateformcon = {'dayofweek': 1, 'addzero': 0,
 ############################################################
 
 if __name__ == "__main__":
-    print((returndate()))
+    print(returndate())
     year, month, day = returndate()
     test = daycount(year, month, day)
     print(test)
-    print((counttodate(test)))
+    print(counttodate(test))
     while True:
         x = eval(input("Enter Year of date (Enter to quit) >> "))
         if x == '':
@@ -621,20 +621,20 @@ if __name__ == "__main__":
         z = eval(input("Enter Day >> "))
         test = daycount(int(x), int(y), int(z))
         print(test)
-        print((counttodate(test)))
+        print(counttodate(test))
 
-    print((realdate(32, 1, 2004)))
+    print(realdate(32, 1, 2004))
     while True:
         x = eval(input("Enter Modifier (0 to quit) >> "))
         if x == '0':
             break
-        print((addnumdays(31, 3, 2004, -int(x))))
+        print(addnumdays(31, 3, 2004, -int(x)))
 
     while True:
         x = eval(input("Enter Day of Week 0-6 (7 to quit) >> "))
         if x == '7':
             break
-        print((nearestday(24, 1, 2004, int(x))))
+        print(nearestday(24, 1, 2004, int(x)))
 
     while True:
         x = eval(input("Enter Years to Add (Enter to quit) >> "))
@@ -642,7 +642,7 @@ if __name__ == "__main__":
             break
         y = eval(input("Enter Months to Add >> "))
         z = eval(input("Enter Days To Add >> "))
-        print((adddate(24, 1, 2004, int(z), int(y), int(x))))
+        print(adddate(24, 1, 2004, int(z), int(y), int(x)))
         year, month, day = adddate(24, 1, 2004, int(z), int(y), int(x))
         print(("The nearest Tuesday after that date is ",
                nearestday(day, month, year)))

--- a/sciflo/utils/filelist.py
+++ b/sciflo/utils/filelist.py
@@ -27,7 +27,7 @@ import sys
 from . import dataenc
 from ftplib import FTP
 from fnmatch import fnmatchcase
-USAGE = """
+USAGE = r"""
 filelist.py [--help] [--bottomUp] [--directory] [--delete]
             [--fetchDir <outputDir>] [--fetchWitSubDirs]
             [--list] [--matchUrl] --quiet] [--regex '.*\.[cC]']
@@ -361,7 +361,7 @@ class FileInfo:
         self.protectMode = protectMode
 
 
-class UserCredential(object):
+class UserCredential:
     """Container for user credential info. like username, password, certificate, etc.
     """
 
@@ -552,7 +552,7 @@ class FtpDirectoryWalker(DirectoryWalker):
         return (dirs, files, infos)
 
 
-class DirListingParser(object):
+class DirListingParser:
     """Base class for directory listing parsers."""
 
     def __init__(self, regex):
@@ -685,7 +685,7 @@ class HttpDirectoryWalker(DirectoryWalker):
                     response = self.opener.open(url)
                 else:
                     response = urllib.request.urlopen(url)
-            except IOError as e:
+            except OSError as e:
                 if hasattr(e, 'reason'):
                     warn(
                         'HttpDirectoryWalker: Error, failed to reach server because: %s' % e.reason)
@@ -711,11 +711,11 @@ class HttpDirectoryWalker(DirectoryWalker):
         if path:
             match = HttpDirectoryWalker.reDirPath.search(dir)
             if not match:
-                die('HttpDirectoryWalker: Cannot find directory name %s in HTML listing:\n%s' % (
+                die('HttpDirectoryWalker: Cannot find directory name {} in HTML listing:\n{}'.format(
                     path, dir))
             dirName = match.group(1)
             if dirName not in path:
-                warn('HttpDirectoryWalker: Directory name %s in HTML listing does not agree with path %s:\n%s' % (
+                warn('HttpDirectoryWalker: Directory name {} in HTML listing does not agree with path {}:\n{}'.format(
                     dirName, path, dir))
 
         # Try to find directory lines that contain file info
@@ -856,7 +856,7 @@ def main():
                                     'url', 'verbose', 'wildcard=', 'xml'])
     except getopt.GetoptError as xxx_todo_changeme:
         (msg, bad_opt) = xxx_todo_changeme.args
-        die("%s error: Bad option: %s, %s" % (argv[0], bad_opt, msg))
+        die("{} error: Bad option: {}, {}".format(argv[0], bad_opt, msg))
 
     regSpecs = []
     wildCards = []

--- a/sciflo/utils/interfaceUtils.py
+++ b/sciflo/utils/interfaceUtils.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 
 from .xmlUtils import getXmlEtree
 
-VIEW_RE = re.compile('^(.+?)\((.*)\)$')
+VIEW_RE = re.compile(r'^(.+?)\((.*)\)$')
 
 
 def parseView(view):
@@ -259,7 +259,7 @@ def getTabConfig(sfl):
             'name': tabName.lower(),
             'title': tabName,
             'validationUrl': 'services/validateSetup',
-            'dbName': ('%s_%s' % (id, tabName)).replace(' ', '_'),
+            'dbName': ('{}_{}'.format(id, tabName)).replace(' ', '_'),
             'items': []
         }
 
@@ -572,7 +572,7 @@ def getTabConfig(sfl):
         for item in cvoTabCfg['items']:
             if 'title' not in item:
                 item['title'] = item['name']
-            groupItem = '%s/%s' % (cvoTabCfg['title'], item['title'])
+            groupItem = '{}/{}'.format(cvoTabCfg['title'], item['title'])
             if groupItem in itemConfig:
                 item['paletteIcon'] = itemConfig[groupItem]['paletteIcon']
 

--- a/sciflo/utils/misc.py
+++ b/sciflo/utils/misc.py
@@ -144,7 +144,7 @@ def getHostIp(host=None):
             host = socket.gethostname()
         return socket.gethostbyname(host)
     except Exception as e:
-        print(("Got exception resolving ip address for host %s: %s" % (host, e)))
+        print("Got exception resolving ip address for host {}: {}".format(host, e))
         return ''
 
 
@@ -296,7 +296,7 @@ in your sciflo configuration." % loc)
 
                 else:
                     print(
-                        ("Package %s already installed and is the latest version." % packageDir))
+                        "Package %s already installed and is the latest version." % packageDir)
         finally:
             if dir:
                 os.chdir(curDir)
@@ -352,8 +352,8 @@ in your sciflo configuration." % loc)
                 # localize
                 dest = sciflo.data.localize.localizeUrl(item, destDir)
             except Exception as e:
-                print(("Got exception trying to retrieve url %s to %s: %s" %
-                       (item, destDir, e)))
+                print("Got exception trying to retrieve url %s to %s: %s" %
+                       (item, destDir, e))
                 continue
         else:
             dest = os.path.join(destDir, os.path.basename(item))
@@ -387,7 +387,7 @@ def resolvePath(file, pathEnviron):
 
     # if nothing came up, raise error
     raise RuntimeError(
-        "Couldn't resolve file %s to a path using %s." % (file, pathEnviron))
+        "Couldn't resolve file {} to a path using {}.".format(file, pathEnviron))
 
 
 def pidIsRunning(pid):
@@ -430,7 +430,7 @@ class UrlBaseTrackerError(Exception):
     pass
 
 
-class UrlBaseTracker(object):
+class UrlBaseTracker:
     """Class that encapsulates the mapping between local dir/files under a
     server root directory and the url of those dir/files."""
 
@@ -455,7 +455,7 @@ class UrlBaseTracker(object):
         # make sure path starts with rootDir
         if not absPath.startswith(self._rootDir):
             if returnFileUrl:
-                return 'file://%s%s' % (socket.getfqdn(), absPath)
+                return 'file://{}{}'.format(socket.getfqdn(), absPath)
             else:
                 return absPath
 
@@ -474,12 +474,12 @@ class UrlBaseTracker(object):
             alreadyLocal = False
         retUrl = url.replace(self._urlBase, self._rootDir)
         if returnFileUrl:
-            return 'file://%s%s' % (socket.getfqdn(), retUrl)
+            return 'file://{}{}'.format(socket.getfqdn(), retUrl)
         else:
             return retUrl
 
 
-class LocalizingFunctionWrapper(object):
+class LocalizingFunctionWrapper:
     """Function wrapper class."""
 
     def __init__(self, func):
@@ -511,7 +511,7 @@ def runCommandLine(cmd):
         if re.search(r'No child processes', str(e), re.IGNORECASE):
             retcode = 0
         else:
-            raise RuntimeError("Execution failed for %s: %s" % (cmd, str(e)))
+            raise RuntimeError("Execution failed for {}: {}".format(cmd, str(e)))
     if retcode < 0:
         raise RuntimeError(
             "Execution failed for %s: Child was terminated by signal %d" % (cmd, -retcode))
@@ -543,15 +543,15 @@ def convertImage(inputFile, outputFile, format=None, convert=None,
                 im.save(*(outputFile, format), **options)
             else:
                 im.save(*(outputFile,), **options)
-    except IOError:
+    except OSError:
         #print >>sys.stderr, "Error using PIL to convert image: %s" % traceback.format_exc()
         #print >>sys.stderr, "Trying convert."
         # try using convert
         if rotate:
-            cmd = "convert -rotate %s -crop 0x0 -size 1280x1024 %s %s" % (
+            cmd = "convert -rotate {} -crop 0x0 -size 1280x1024 {} {}".format(
                 abs(rotate), inputFile, outputFile)
         else:
-            cmd = "convert -crop 0x0 -size 1280x1024 %s %s" % (
+            cmd = "convert -crop 0x0 -size 1280x1024 {} {}".format(
                 inputFile, outputFile)
         runCommandLine(cmd)
     return True
@@ -591,7 +591,7 @@ def getFlashMovie(imageFiles, outputFile=None):
         pngFiles.append(pngFile)
     movieFile = outputFile + '.tmp1.swf'
     output = runCommandLine(
-        'png2swf -o %s -X 700 -Y 500 -j 100 %s' % (movieFile, ' '.join(pngFiles)))
+        'png2swf -o {} -X 700 -Y 500 -j 100 {}'.format(movieFile, ' '.join(pngFiles)))
     movieFile2 = outputFile + '.tmp2.swf'
     output = runCommandLine('swfcombine -o %s -X 700 -Y 500 %s viewport=%s' %
                             (movieFile2, os.path.join(sys.prefix, 'share', 'swftools', 'swfs',
@@ -992,7 +992,7 @@ def getUserScifloConfig(userConfigFile=None, globalConfigFile=None):
     # write config file if it doesn't exist, otherwise check if it needs to be updated
     configStr_from_file = None
     if os.path.exists(userScifloConfigFile):
-        with open(userScifloConfigFile, 'r') as f:
+        with open(userScifloConfigFile) as f:
             configStr_from_file = f.read()
     if configStr_from_file is None or configStr_from_file != configStr:
         with open(userScifloConfigFile, 'w') as f:
@@ -1204,7 +1204,7 @@ def runDot(dot, outputFile=None, outputType=None):
     try:
         dotFile, headers = urlllib.urlretrieve(dot)
     except:
-        if re.search('}\s*$', dot):
+        if re.search(r'}\s*$', dot):
             tmpFlag = True
             dotFile = getTempfileName(suffix='.dot')
             with open(dotFile, 'w') as f:
@@ -1217,7 +1217,7 @@ def runDot(dot, outputFile=None, outputType=None):
             outputType = ext
         else:
             raise RuntimeError("Unknown extension %s." % ext)
-    runCommandLine("dot -T%s -o %s %s" % (ext, outputFile, dotFile))
+    runCommandLine("dot -T{} -o {} {}".format(ext, outputFile, dotFile))
     if headers:
         urllib.request.urlcleanup()
     try:

--- a/sciflo/utils/xmlIndent.py
+++ b/sciflo/utils/xmlIndent.py
@@ -89,9 +89,9 @@ def getInputStream(xml=None):
     if xml is None:
         stream = sys.stdin
     elif isinstance(xml, str):
-        if re.match('\s*<', xml):
+        if re.match(r'\s*<', xml):
             xml = xml.replace('\n', '')
-            if not re.match('(?is)\s*<\?xml', xml):
+            if not re.match(r'(?is)\s*<\?xml', xml):
                 xml = '<?xml version = "1.0"?>\n' + xml
             # print xml
             stream = StringIO(xml)
@@ -116,7 +116,7 @@ def indent(xmls, indent='  ', newline='\n', header=True):
         die(e)
     xmlFragment = outs.getvalue()
     if not header:
-        match = re.match('(?is)\s*<\?xml.*?\?>\s*(.*)$', xmlFragment)
+        match = re.match(r'(?is)\s*<\?xml.*?\?>\s*(.*)$', xmlFragment)
         if match:
             xmlFragment = match.group(1)
     return xmlFragment
@@ -132,4 +132,4 @@ if __name__ == "__main__":
     except:
         url = None
 
-    print((indent(url)))
+    print(indent(url))

--- a/sciflo/utils/xmlUtils.py
+++ b/sciflo/utils/xmlUtils.py
@@ -75,7 +75,7 @@ def getXmlEtree(xml):
     else:
         protocol, netloc, path, params, query, frag = urlparse(xml)
         if protocol == '':
-            xml = "file://{}".format(xml)
+            xml = f"file://{xml}"
         xmlStr = urlopen(xml).read().decode('utf-8')
         return (lxml.etree.parse(StringIO(xmlStr), parser).getroot(), getNamespacePrefixDict(xmlStr))
 
@@ -137,12 +137,12 @@ def runXpath(xml, xpathStr, nsDict={}):
                     pass
                 else:
                     raise RuntimeError(
-                        "Error in xpath expression %s: %s" % (xpathStr, e.error_log))
+                        "Error in xpath expression {}: {}".format(xpathStr, e.error_log))
             try:
                 res = root.xpath(xpathStr, namespaces=nsDict)
             except lxml.etree.XPathSyntaxError as e:
                 raise RuntimeError(
-                    "Error in xpath expression %s: %s" % (xpathStr, e.error_log))
+                    "Error in xpath expression {}: {}".format(xpathStr, e.error_log))
             except:
                 gotException = True
                 res = []
@@ -153,7 +153,7 @@ def runXpath(xml, xpathStr, nsDict={}):
                 res = root.xpath(xpathStr, namespaces=nsDict)
             except lxml.etree.XPathSyntaxError as e:
                 raise RuntimeError(
-                    "Error in xpath expression %s: %s" % (xpathStr, e.error_log))
+                    "Error in xpath expression {}: {}".format(xpathStr, e.error_log))
             except:
                 raise
     if isinstance(res, (list, tuple)):
@@ -776,7 +776,7 @@ class ScifloConfigParserError(Exception):
     pass
 
 
-class ScifloConfigParser(object):
+class ScifloConfigParser:
     """Class that parses the sciflo configuration xml file and provides
     parameter values.
     """
@@ -801,7 +801,7 @@ class ScifloConfigParser(object):
     def getParameter(self, param):
         """Return the parameter value.  Returns None if not specified."""
 
-        param2Get = ".//{%s}%s" % (SCIFLO_NAMESPACE, param)
+        param2Get = ".//{{{}}}{}".format(SCIFLO_NAMESPACE, param)
         result = self._xmlDoc.find(param2Get)
         if result in [None, 'None', ''] or result.text in [None, 'None', '']:
             return None
@@ -949,7 +949,7 @@ def getTypedValue(typ, val):
     # For now we'll leave it up to the endpoint (soap service,
     # function, etc.) to handle type conversion.
     ##########################################################
-    '''
+    r'''
     #return typed val
     #if date
     if xsdType == 'date':

--- a/sciflo/utils/xmldb.py
+++ b/sciflo/utils/xmldb.py
@@ -159,7 +159,7 @@ class XmlDb:
         if namespaces is not None:
             for prefix, uri in namespaces.items():
                 if self.verbose:
-                    warn('xmldb: setNamespace %s: %s' % (prefix, uri))
+                    warn('xmldb: setNamespace {}: {}'.format(prefix, uri))
                 queryContext.setNamespace(prefix, uri)
         self.queryContext = queryContext
         return self
@@ -260,7 +260,7 @@ def xquerySingleDoc(doc, query, namespaces={}, verbose=False):
     namespaces.update(extractNamespaces(doc))
     for prefix, uri in namespaces.items():
         if verbose:
-            warn('xmldb: setNamespace %s: %s' % (prefix, uri))
+            warn('xmldb: setNamespace {}: {}'.format(prefix, uri))
         queryContext.setNamespace(prefix, uri)
 
     queryProlog = 'declare namespace my = "http://fubar.net/my";\n'
@@ -332,8 +332,8 @@ def extractNamespaces3(doc):
         else:
             return '_default'
 
-    return dict([(getPrefix(attrib), ns) for attrib, ns in elt.attrib.items()
-                 if attrib.startswith('xmlns') for elt in XML(doc).getiterator()])
+    return {getPrefix(attrib): ns for attrib, ns in elt.attrib.items()
+                 if attrib.startswith('xmlns') for elt in XML(doc).getiterator()}
 
 
 # Utilities follow.
@@ -358,7 +358,7 @@ if __name__ == "__main__":
                                    ['help', 'namespace', 'prefix', 'query', 'queryUrl', 'verbose'])
     except getopt.GetoptError as xxx_todo_changeme:
         (msg, bad_opt) = xxx_todo_changeme.args
-        die("%s error: Bad option: %s, %s" % (argv[0], bad_opt, msg))
+        die("{} error: Bad option: {}, {}".format(argv[0], bad_opt, msg))
 
     query = None
     queryUrl = None

--- a/scripts/crawlAll.py
+++ b/scripts/crawlAll.py
@@ -23,14 +23,14 @@ from sciflo.utils import *
 lockFile = os.path.join(tempfile.gettempdir(),
                         'crawler.%s.lck' % getpass.getuser())
 if os.path.exists(lockFile):
-    lockingPid = open(lockFile, 'r').read()
+    lockingPid = open(lockFile).read()
     if os.path.isdir(os.path.join('/proc', lockingPid)) and lockingPid != '':
-        print(("%s: Process %s already running." %
-               (DT.utcfromtimestamp(time.time()).isoformat(), lockingPid)))
+        print("%s: Process %s already running." %
+               (DT.utcfromtimestamp(time.time()).isoformat(), lockingPid))
         sys.exit(0)
     else:
-        print(("%s: Zombie process?  Removed lock with pid %s." %
-               (DT.utcfromtimestamp(time.time()).isoformat(), lockingPid)))
+        print("%s: Zombie process?  Removed lock with pid %s." %
+               (DT.utcfromtimestamp(time.time()).isoformat(), lockingPid))
         os.unlink(lockFile)
 
 # create lock file
@@ -48,9 +48,9 @@ if dbUser in [None, 'None', '']:
     schema = 'mysql://127.0.0.1:%s/urlCatalog' % dbPort
 else:
     if dbPassword in [None, 'None', '']:
-        schema = 'mysql://%s@127.0.0.1:%s/urlCatalog' % (dbUser, dbPort)
+        schema = 'mysql://{}@127.0.0.1:{}/urlCatalog'.format(dbUser, dbPort)
     else:
-        schema = 'mysql://%s:%s@127.0.0.1:%s/urlCatalog' % (
+        schema = 'mysql://{}:{}@127.0.0.1:{}/urlCatalog'.format(
             dbUser, dbPassword, dbPort)
 crawlerConfigDir = os.path.join(sys.prefix, 'etc', 'crawler')
 
@@ -75,5 +75,5 @@ for xmlConfigFile in xmlConfigFiles:
 
 # remove lock file
 os.unlink(lockFile)
-print(("%s: Script finished.  Removed lock with pid %s." %
-       (DT.utcfromtimestamp(time.time()).isoformat(), currentPid)))
+print("%s: Script finished.  Removed lock with pid %s." %
+       (DT.utcfromtimestamp(time.time()).isoformat(), currentPid))

--- a/scripts/getConfigVal.py
+++ b/scripts/getConfigVal.py
@@ -17,7 +17,7 @@ from sciflo.utils import ScifloConfigParser
 
 def usage():
     """Print usage info."""
-    print(("""%s <config field>""" % sys.argv[0]))
+    print("""%s <config field>""" % sys.argv[0])
 
 
 # make sure right number of arguments provided
@@ -29,4 +29,4 @@ if len(sys.argv) != 2:
 scp = ScifloConfigParser()
 
 # print
-print((scp.getParameter(sys.argv[1])))
+print(scp.getParameter(sys.argv[1]))

--- a/scripts/insertDataFromXml.py
+++ b/scripts/insertDataFromXml.py
@@ -20,9 +20,9 @@ import sciflo
 
 def usage():
     """Print usage info."""
-    print(("""%s [-l|--location <location>] [-t|--table <table>] [-u|--update] \
+    print("""%s [-l|--location <location>] [-t|--table <table>] [-u|--update] \
 [-r|--recordTag <tag>] [-k|--keyTags <tag1,tag2,tag3,...>] [-d|--debug] \
-[-h|--help] <xml doc>""" % sys.argv[0]))
+[-h|--help] <xml doc>""" % sys.argv[0])
 
 
 def main():
@@ -113,7 +113,7 @@ def main():
 
     # xml doc
     doc = args[0]
-    f = open(doc, 'r')
+    f = open(doc)
     xml = f.read()
     f.close()
 
@@ -131,7 +131,7 @@ def main():
         ret = sciflo.db.insertXml(location, table, xml, **kargs)
     except etree.XMLSyntaxError as e:
         print("Got XMLSyntaxError:")
-        print((e.error_log.filter_levels(etree.ErrorLevels.FATAL)))
+        print(e.error_log.filter_levels(etree.ErrorLevels.FATAL))
         print("Please check xml.")
     except sciflo.db.NoIndexedFieldsInXmlError as e:
         print(

--- a/scripts/ldapAuth.py
+++ b/scripts/ldapAuth.py
@@ -24,15 +24,15 @@ def authenticate(user, passwd):
     except ldap.NO_SUCH_OBJECT as e:
         info = e.args[0]['info']
         desc = e.args[0]['desc']
-        print(("%s: %s" % (info, desc)))
+        print("{}: {}".format(info, desc))
     except ldap.INVALID_CREDENTIALS as e:
         info = e.args[0]['info']
         desc = e.args[0]['desc']
-        print(("%s: %s" % (info, desc)))
+        print("{}: {}".format(info, desc))
     except ldap.INAPPROPRIATE_AUTH as e:
         info = e.args[0]['info']
         desc = e.args[0]['desc']
-        print(("%s: %s" % (info, desc)))
+        print("{}: {}".format(info, desc))
     os.unlink(certFile)
 
 

--- a/scripts/ldapSearch.py
+++ b/scripts/ldapSearch.py
@@ -45,10 +45,10 @@ except ldap.LDAPError as e:
 
 if len(result_set) > 0:
     for result in result_set:
-        print(("#" * 80))
-        print((result[0][0]))
+        print("#" * 80)
+        print(result[0][0])
         for key in list(result[0][1].keys()):
-            print(("%s: %s" % (key, '\n\t'.join(result[0][1][key]))))
-        print(("#" * 80))
+            print("{}: {}".format(key, '\n\t'.join(result[0][1][key])))
+        print("#" * 80)
 else:
     print("No entries found.")

--- a/scripts/sflExec.py
+++ b/scripts/sflExec.py
@@ -31,9 +31,9 @@ import sciflo
 def usage():
     """Print usage info."""
 
-    print(("""%s [-c|--configFile <config file>] [-i|--init] [-o|--outputDir <output dir>]\
+    print("""%s [-c|--configFile <config file>] [-i|--init] [-o|--outputDir <output dir>]\
 [-s|--status] [-f|--force] [-d|--debug] [--nocache] [-t|--timeout <seconds>]\
-[-a|--args <input1=val1,input2=val2,...>] [-v|--verbose] [-h|--help] <sciflo doc>""" % sys.argv[0]))
+[-a|--args <input1=val1,input2=val2,...>] [-v|--verbose] [-h|--help] <sciflo doc>""" % sys.argv[0])
 
 
 def main():
@@ -152,8 +152,8 @@ def main():
             usage()
             sys.exit(2)
         userScifloConfig = sciflo.utils.getUserScifloConfig(configFile)
-        print(("Your sciflo configuration directory has been initialized: %s" %
-               os.path.dirname(userScifloConfig)))
+        print("Your sciflo configuration directory has been initialized: %s" %
+               os.path.dirname(userScifloConfig))
         sys.exit(0)
 
     # if showStatus, do debug mode since stderr and stdout won't be put to the screen
@@ -181,7 +181,7 @@ def main():
 
     # sciflo doc
     doc = args[0]
-    f = open(doc, 'r')
+    f = open(doc)
     xml = f.read()
     f.close()
 
@@ -268,7 +268,7 @@ if __name__ == '__main__':
             sys.exit(0)
         if sys.exc_info()[0] is not None and sys.exc_info()[0] != _curses.error:
             traceback.print_exc(file=tracebackStrIO)
-            print((tracebackStrIO.getvalue()))
+            print(tracebackStrIO.getvalue())
     # if resStrList: print '\n'.join(resStrList)
     print(("Results:", results))
     if isinstance(results, Exception):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ scripts = [os.path.join('scripts', 'sflExec.py'),
 data_files = [('tac', [os.path.join('tac', 'PersistentDictServer.tac')])]
 
 setup(name='sciflo',
-      version = "1.3.7",
+      version = "1.4.0",
       description="SciFlo workflow framework and engine",
       url="https://github.com/hysds/sciflo",
       author='Brian Wilson',

--- a/test/executor/executorTest.py
+++ b/test/executor/executorTest.py
@@ -48,6 +48,7 @@ class ExecutorTestCase(unittest.TestCase):
         # run
         return sciflo.grid.executor.runSciflo(sfl, {}, timeout=None,
                                               outputDir=self.outputDir,
+                                              workers=2,
                                               configDict={'isLocal': True})
 
     def testAll(self):

--- a/test/executor/testExec.py
+++ b/test/executor/testExec.py
@@ -14,5 +14,5 @@ else:
 workers = 4
 timeout = 86400
 
-print((runSciflo(sflString, args={}, pklFile=pklFile, workers=workers,
-                 timeout=timeout)))
+print(runSciflo(sflString, args={}, pklFile=pklFile, workers=workers,
+                 timeout=timeout))

--- a/test/executor/testScript.py
+++ b/test/executor/testScript.py
@@ -1,5 +1,5 @@
 import time
 import testModule2
 
-print(("Random number is %s at epoch %s." % (testModule2.getRandomNum(),
-                                             time.time())))
+print("Random number is {} at epoch {}.".format(testModule2.getRandomNum(),
+                                             time.time()))

--- a/test/executor/test_sciflo_chain.py
+++ b/test/executor/test_sciflo_chain.py
@@ -41,10 +41,10 @@ def run_query(url, idx, query, doc_type=None):
     else:
         query_url = "{}/{}/{}/_search?search_type=scan&scroll=60&size=100".format(
             url, idx, doc_type)
-    logger.info("url: {}".format(url))
-    logger.info("idx: {}".format(idx))
-    logger.info("doc_type: {}".format(doc_type))
-    logger.info("query: {}".format(json.dumps(query, indent=2)))
+    logger.info(f"url: {url}")
+    logger.info(f"idx: {idx}")
+    logger.info(f"doc_type: {doc_type}")
+    logger.info(f"query: {json.dumps(query, indent=2)}")
     r = requests.post(query_url, data=json.dumps(query))
     r.raise_for_status()
     scan_result = r.json()
@@ -76,13 +76,13 @@ def job_done(url, idx, task_id, doc_type=None):
         },
         "fields": [ "status" ],
     }
-    logger.info("query_status: {}".format(json.dumps(query_status, indent=2)))
+    logger.info(f"query_status: {json.dumps(query_status, indent=2)}")
     res = run_query(url, idx, query_status)
-    logger.info("got res: {}".format(json.dumps(res, indent=2)))
+    logger.info(f"got res: {json.dumps(res, indent=2)}")
     status = res[0]['fields']['status'][0]
-    logger.info("got status: {}".format(json.dumps(status, indent=2)))
+    logger.info(f"got status: {json.dumps(status, indent=2)}")
     if status == 'job-started':
-        raise RuntimeError("Job with task ID {} still in 'job-started' state.".format(task_id))
+        raise RuntimeError(f"Job with task ID {task_id} still in 'job-started' state.")
     return True
 
 
@@ -100,13 +100,13 @@ def create_job(arg, job_queue, wuid=None, job_num=None):
         "dt": datetime.utcnow().isoformat(),
     }
     job = resolve_hysds_job(job_type, job_queue, priority=0, params=params,
-                            job_name="%s-%s" % (job_type, params['dt']),
+                            job_name="{}-{}".format(job_type, params['dt']),
                             payload_hash=get_payload_hash(params))
 
     # add workflow info
     job['payload']['_sciflo_wuid'] = wuid
     job['payload']['_sciflo_job_num'] = job_num
-    logger.info("job: {}".format(json.dumps(job, indent=2)))
+    logger.info(f"job: {json.dumps(job, indent=2)}")
 
     return job
 
@@ -125,13 +125,13 @@ def create_merge_job(arg1, arg2, job_queue, wuid=None, job_num=None):
         "dt": datetime.utcnow().isoformat(),
     }
     job = resolve_hysds_job(job_type, job_queue, priority=0, params=params,
-                            job_name="%s-%s" % (job_type, params['dt']),
+                            job_name="{}-{}".format(job_type, params['dt']),
                             payload_hash=get_payload_hash(params))
 
     # add workflow info
     job['payload']['_sciflo_wuid'] = wuid
     job['payload']['_sciflo_job_num'] = job_num
-    logger.info("job: {}".format(json.dumps(job, indent=2)))
+    logger.info(f"job: {json.dumps(job, indent=2)}")
 
     return job
 
@@ -139,7 +139,7 @@ def create_merge_job(arg1, arg2, job_queue, wuid=None, job_num=None):
 def get_result(result):
     """Evaluator function for processing a job result."""
 
-    logger.info("got result: {}".format(json.dumps(result, indent=2)))
+    logger.info(f"got result: {json.dumps(result, indent=2)}")
     task_id = result[0]
     done = job_done(app.conf['JOBS_ES_URL'], 'job_status-current', task_id)
     query = {
@@ -150,9 +150,9 @@ def get_result(result):
         }
     }
     jobs = run_query(app.conf['JOBS_ES_URL'], 'job_status-current', query)
-    logger.info("got job: {}".format(json.dumps(jobs[0], indent=2)))
+    logger.info(f"got job: {json.dumps(jobs[0], indent=2)}")
     dataset_id = jobs[0]['_source']['job']['job_info']['metrics']['products_staged'][0]['id']
-    logger.info("got dataset_id: {}".format(dataset_id))
+    logger.info(f"got dataset_id: {dataset_id}")
     return dataset_id
 
 

--- a/test/utils/xmlSchemaValidationTest.py
+++ b/test/utils/xmlSchemaValidationTest.py
@@ -37,10 +37,10 @@ badxmlFile = os.path.join(dirName, 'test_bad.xml')
 unwellformedxmlFile = os.path.join(dirName, 'test_notwellformed.xml')
 
 # crawler xml as string
-crawlerSchemaXml = open(schemaFile, 'r').read()
+crawlerSchemaXml = open(schemaFile).read()
 
 # xml as string
-xmlString = open(xmlFile, 'r').read()
+xmlString = open(xmlFile).read()
 
 
 class utilsTestCase(unittest.TestCase):

--- a/test/utils/xmlUtilsTest.py
+++ b/test/utils/xmlUtilsTest.py
@@ -278,9 +278,9 @@ class xmlUtilsTestCase(unittest.TestCase):
         """Test XSLT transformation using xml string and xsl string."""
 
         # get strings
-        with open(xmlFile, 'r') as f:
+        with open(xmlFile) as f:
             xmlString = f.read()
-        with open(xslFile, 'r') as f:
+        with open(xslFile) as f:
             xslString = f.read()
 
         # get transformed xml
@@ -293,7 +293,7 @@ class xmlUtilsTestCase(unittest.TestCase):
         """Test XSLT transformation using xml string and xsl file."""
 
         # get strings
-        with open(xmlFile, 'r') as f:
+        with open(xmlFile) as f:
             xmlString = f.read()
 
         # get transformed xml
@@ -306,7 +306,7 @@ class xmlUtilsTestCase(unittest.TestCase):
         """Test XSLT transformation using xml file and xsl string."""
 
         # get strings
-        with open(xslFile, 'r') as f:
+        with open(xslFile) as f:
             xslString = f.read()
 
         # get transformed xml


### PR DESCRIPTION
- This PR updates the code to be compatible with Python 3.12
- Updates were made by running the `pyupgrade` tool
- ExecutorTest was updated so that it uses only 2 workers as opposed to 4, which was the default. This lead to the tests occasionally hanging, likely due to exhaustion of available resources.